### PR TITLE
Upstream Changes & omniauth-oauth2 v.1.4.0 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ So let's say you're using Rails, you need to add the strategy to your `Gemfile`:
 
 You can pull it in directly from github (if you really want to) e.g.:
 
-    gem 'omniauth-square', :git => 'https://github.com/danieljacobarcher/omniauth-square.git'
+    gem 'omniauth-square', :git => 'https://github.com/dja/omniauth-square.git'
 
 Once these are in, you need to add the following to your `config/initializers/omniauth.rb`:
 
@@ -23,13 +23,13 @@ Once these are in, you need to add the following to your `config/initializers/om
       	}
     end
 
-You will obviously have to put in your key and secret, which you get when you register your app with Square (they call them Application Key and Secret Key). 
+You will obviously have to put in your key and secret, which you get when you register your app with Square (they call them Application Key and Secret Key).
 
 Now just follow the README at: https://github.com/intridea/omniauth
 
 ## License
 
-Copyright (c) 2013 by [Daniel Archer](https://github.com/danieljacobarcher/), [Jen Aprahamian](https://github.com/jennifermarie/), [Adam Bouck](https://github.com/abouck/), [Ray Zane](https://github.com/rzane)
+Copyright (c) 2013 by [Daniel Archer](https://github.com/dja/), [Jen Aprahamian](https://github.com/jennifermarie/), [Adam Bouck](https://github.com/abouck/), [Ray Zane](https://github.com/rzane)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Square uses the OAuth2 flow, you can read about it here: http://connect.squareup
 
 So let's say you're using Rails, you need to add the strategy to your `Gemfile`:
 
-    gem 'omniauth-square', '~> 1.0'
+    gem 'omniauth-square', '~> 1.0.2'
 
 You can pull it in directly from github (if you really want to) e.g.:
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ This gem contains the Square strategy for OmniAuth.
 
 Square uses the OAuth2 flow, you can read about it here: http://connect.squareup.com
 
-## What's in This Fork?
+## How To Use It
 
-This fork patches support in for `omniauth-oauth2` up to v1.4.0 as opposed to anything less than v1.3.0.
+So let's say you're using Rails, you need to add the strategy to your `Gemfile`:
 
-## How to Use It
+    gem 'omniauth-square', '~> 1.0'
 
-You can pull it in directly from github:
+You can pull it in directly from github (if you really want to) e.g.:
 
-    gem 'omniauth-square', :git => 'https://github.com/grepme/omniauth-square.git'
+    gem 'omniauth-square', :git => 'https://github.com/danieljacobarcher/omniauth-square.git'
 
 Once these are in, you need to add the following to your `config/initializers/omniauth.rb`:
 
@@ -23,13 +23,13 @@ Once these are in, you need to add the following to your `config/initializers/om
       	}
     end
 
-You will obviously have to put in your key and secret, which you get when you register your app with Square (they call them Application Key and Secret Key).
+You will obviously have to put in your key and secret, which you get when you register your app with Square (they call them Application Key and Secret Key). 
 
 Now just follow the README at: https://github.com/intridea/omniauth
 
 ## License
 
-Copyright (c) 2013 by [Daniel Archer](https://github.com/dja/), [Jen Aprahamian](https://github.com/jennifermarie/), [Adam Bouck](https://github.com/abouck/), [Ray Zane](https://github.com/rzane)
+Copyright (c) 2013 by [Daniel Archer](https://github.com/danieljacobarcher/), [Jen Aprahamian](https://github.com/jennifermarie/), [Adam Bouck](https://github.com/abouck/), [Ray Zane](https://github.com/rzane)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ This gem contains the Square strategy for OmniAuth.
 
 Square uses the OAuth2 flow, you can read about it here: http://connect.squareup.com
 
-## How To Use It
+## What's in This Fork?
 
-So let's say you're using Rails, you need to add the strategy to your `Gemfile`:
+This fork patches support in for `omniauth-oauth2` up to v1.4.0 as opposed to anything less than v1.3.0.
 
-    gem 'omniauth-square', '~> 1.0.2'
+## How to Use It
 
-You can pull it in directly from github (if you really want to) e.g.:
+You can pull it in directly from github:
 
-    gem 'omniauth-square', :git => 'https://github.com/dja/omniauth-square.git'
+    gem 'omniauth-square', :git => 'https://github.com/grepme/omniauth-square.git'
 
 Once these are in, you need to add the following to your `config/initializers/omniauth.rb`:
 

--- a/lib/omniauth-square/version.rb
+++ b/lib/omniauth-square/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Square
-    VERSION = "1.0"
+    VERSION = "1.0.2"
   end
 end

--- a/lib/omniauth/strategies/square.rb
+++ b/lib/omniauth/strategies/square.rb
@@ -60,7 +60,7 @@ module OmniAuth
           :redirect_uri => callback_url
         }
 
-        params.merge! client.auth_code.client_params
+        params.merge! client_params
         params.merge! token_params.to_hash(:symbolize_keys => true)
 
         opts = {
@@ -80,6 +80,10 @@ module OmniAuth
           prune!(value) if value.is_a?(Hash)
           value.nil? || (value.respond_to?(:empty?) && value.empty?)
         end
+      end
+
+      def client_params
+        {:client_id => client.id, :client_secret => client.secret}
       end
     end
   end

--- a/omniauth-square.gemspec
+++ b/omniauth-square.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1', '< 1.3.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1', '<= 1.4.0'
   s.add_development_dependency 'rspec', '~> 2.7'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'simplecov'

--- a/omniauth-square.gemspec
+++ b/omniauth-square.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = Omniauth::Square::VERSION
   s.authors     = ["Daniel Archer", "Jennifer Aprahamian", "Adam Bouck", "Ray Zane"]
   s.email       = ["me@dja.io", "j.aprahamian@gmail.com", "adam.j.bouck@gmail.com", "raymondzane@gmail.com"]
-  s.homepage    = "https://github.com/danieljacobarcher/omniauth-square"
+  s.homepage    = "https://github.com/dja/omniauth-square"
   s.summary     = %q{Square OAuth strategy for OmniAuth}
   s.description = %q{Square OAuth strategy for OmniAuth}
   s.license           = "MIT"

--- a/omniauth-square.gemspec
+++ b/omniauth-square.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.1'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1', '< 1.3.0'
   s.add_development_dependency 'rspec', '~> 2.7'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
# What's in this PR?

This primarily adds omniauth-auth2 v.13.0 & v.1.4.0 support via a simple patch on `client_params` which otherwise would error out. The changes originate from my repository: https://github.com/grepme/omniauth-square

## Validation
Specs fail on omniauth-oauth2 1.3.0 and 1.4.0 normally without any changes which is what we were seeing. Some TDD later and the specs now pass.

`client_params` use to be in `OAuth2::Strategy::Base`
https://github.com/intridea/oauth2/blob/0b0c322dceadaf00227431bc8160fb2bf1f26837/lib/oauth2/strategy/base.rb#L12

You can see it was removed in a later version
https://github.com/intridea/oauth2/blob/v1.3.0/lib/oauth2/strategy/auth_code.rb

However, all the `client_params` hash is is the id and secret which are readily available in `OAuth2::Client`
https://github.com/intridea/oauth2/blob/ce913effe4ddaa3b34755753a2e4d1ee7526344f/lib/oauth2/client.rb#L30-L31

More details can be found in the ticket(3872).

## QA
- [x] This has been QA'd by the PR owner
- [ ] This has been QA'd by the approver